### PR TITLE
Add GitHub status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AI Counsel
 
+[![GitHub stars](https://img.shields.io/github/stars/blueman82/ai-counsel)](https://github.com/blueman82/ai-counsel)
+[![GitHub forks](https://img.shields.io/github/forks/blueman82/ai-counsel)](https://github.com/blueman82/ai-counsel)
+[![GitHub last commit](https://img.shields.io/github/last-commit/blueman82/ai-counsel)](https://github.com/blueman82/ai-counsel)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)]()


### PR DESCRIPTION
## Summary
Added three dynamic GitHub badges (stars, forks, last commit) to the README header for improved project visibility and activity tracking.

## Changes
- Stars badge: Shows current repository star count
- Forks badge: Shows current fork count
- Last commit badge: Shows most recent commit timestamp
- All badges link to the repository

## Motivation
Aligns with similar projects (like claude-telegram-bridge) and provides at-a-glance visibility into project activity and community adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)