### PR TITLE
Update Status section to match claude-telegram-bridge format

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,10 +509,13 @@ Inspired by the need for true deliberative AI consensus beyond parallel opinion 
 
 ---
 
-## Status
+## 🚦 Status
 
-[![Build](https://img.shields.io/badge/build-passing-brightgreen)]()
-[![Tests](https://img.shields.io/badge/tests-74+%20passing-green)]()
-[![Version](https://img.shields.io/badge/version-1.1.0-blue)]()
+![GitHub stars](https://img.shields.io/github/stars/blueman82/ai-counsel)
+![GitHub forks](https://img.shields.io/github/forks/blueman82/ai-counsel)
+![GitHub last commit](https://img.shields.io/github/last-commit/blueman82/ai-counsel)
+![Build](https://img.shields.io/badge/build-passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-74+%20passing-green)
+![Version](https://img.shields.io/badge/version-1.1.0-blue)
 
 **Production Ready** - Multi-model deliberative consensus with structured voting and adaptive early stopping for critical technical decisions!


### PR DESCRIPTION
## Summary
Updated the Status section to exactly match the format used in claude-telegram-bridge.

## Changes
- Added emoji icon 🚦 to section heading
- Combined all 6 badges (GitHub stats + Build/Tests/Version) in Status section
- Changed from clickable link syntax to plain image syntax
- GitHub stars, forks, and last commit now appear in Status section with build/test/version info

## Before
```
## Status

[![Build](...))]()
[![Tests](...))]()
[![Version](...))]()
```

## After
```
## 🚦 Status

![GitHub stars](...)
![GitHub forks](...)
![GitHub last commit](...)
![Build](...)
![Tests](...)
![Version](...)
```

This creates complete consistency with claude-telegram-bridge README structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)