### PR TITLE
Remove duplicate GitHub badges from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 True deliberative consensus MCP server where AI models debate and refine positions across multiple rounds.
 
-![GitHub stars](https://img.shields.io/github/stars/blueman82/ai-counsel)
-![GitHub forks](https://img.shields.io/github/forks/blueman82/ai-counsel)
-![GitHub last commit](https://img.shields.io/github/last-commit/blueman82/ai-counsel)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)


### PR DESCRIPTION
## Summary
Removed duplicate GitHub badges (stars, forks, last commit) from the header section.

## Changes
- GitHub badges now appear **only** in the Status section at the bottom
- Header retains only project/code quality badges: License, Python version, Platform, MCP, Code style
- Eliminates duplication while maintaining clean information hierarchy

## Result
- Header section: 5 unique badges (License, Python, Platform, MCP, Code style)
- Status section: 6 badges (GitHub stats + Build/Tests/Version)
- No duplication across the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)