### PR TITLE
Finalize auto-context detection with explicit is_deliberation parameter

### DIFF
--- a/deliberation/engine.py
+++ b/deliberation/engine.py
@@ -124,7 +124,8 @@ class DeliberationEngine:
                 response_text = await adapter.invoke(
                     prompt=enhanced_prompt,
                     model=participant.model,
-                    context=context
+                    context=context,
+                    is_deliberation=True  # Always True during deliberations
                 )
             except Exception as e:
                 # Log error but continue with other participants


### PR DESCRIPTION
## Summary
Finalized the auto-context detection implementation with explicit parameter passing for clarity.

## Changes
- Made `is_deliberation=True` explicit in `execute_round()` when invoking adapters
- Improves code readability and documents intent
- Prevents confusion about default behavior

## Testing
**Scenario 1: Deliberation (✅ VERIFIED)**
- Models fully engage without redirects
- Claude provides substantive analysis instead of saying "use AI Counsel"
- Both Claude and Codex debate properly
- Result: Full deliberation works as intended

**Scenario 2: Claude Code Work (READY)**
- Code is in place to auto-add -p flag when `is_deliberation=False`
- Would be invoked by future features or direct adapter usage
- Currently all deliberations use `is_deliberation=True` (default behavior)

## Benefits
✅ Auto-context detection works seamlessly  
✅ Deliberations fully functional  
✅ Foundation laid for future Claude Code integration  
✅ Zero user configuration needed  

🤖 Generated with [Claude Code](https://claude.com/claude-code)