### PR TITLE
feat: add GPT-5.2 models, remove xhigh reasoning effort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,7 +420,7 @@ from models.schema import Participant, DeliberateRequest
 request = DeliberateRequest(
     question="Complex architecture question",
     participants=[
-        Participant(cli="codex", model="gpt-5.1-codex", reasoning_effort="high"),  # Overrides config default
+        Participant(cli="codex", model="gpt-5.2-codex", reasoning_effort="high"),  # Overrides config default
         Participant(cli="droid", model="claude-opus-4-5-20251101", reasoning_effort="medium"),
         Participant(cli="claude", model="claude-sonnet-4-5-20250929"),  # No reasoning_effort (N/A)
         Participant(cli="codex", model="gpt-5.1-codex-mini"),  # Uses config default_reasoning_effort
@@ -430,7 +430,7 @@ request = DeliberateRequest(
 )
 
 # Adapter support matrix:
-# - codex: none, minimal, low, medium, high, xhigh (injected as -c model_reasoning_effort="...")
+# - codex: none, minimal, low, medium, high (injected as -c model_reasoning_effort="...")
 # - droid: off, low, medium, high (injected as -r flag)
 # - claude/gemini/llamacpp: N/A (reasoning_effort ignored)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ mcp__ai-counsel__deliberate({
   question: "Should we use REST or GraphQL for our new API?",
   participants: [
     {cli: "claude", model: "claude-sonnet-4-5-20250929"},
-    {cli: "codex", model: "gpt-5.1-codex"},
+    {cli: "codex", model: "gpt-5.2-codex"},
     {cli: "gemini", model: "gemini-2.5-pro"}
   ],
   mode: "conference",
@@ -103,7 +103,7 @@ mcp__ai-counsel__deliberate({
 >
 > **Not Recommended**: Models under 3B parameters (e.g., Llama-3.2-1B) may struggle with complex instructions and produce invalid votes.
 
-**Available Models**: `claude` (opus 4.5, sonnet, haiku), `codex` (gpt-5.1-codex), `droid`, `gemini`, HTTP adapters (ollama, lmstudio, openrouter).
+**Available Models**: `claude` (opus 4.5, sonnet, haiku), `codex` (gpt-5.2-codex, gpt-5.1-codex-max, gpt-5.1-codex-mini, gpt-5.2), `droid`, `gemini`, HTTP adapters (ollama, lmstudio, openrouter).
 See [CLI Model Reference](docs/CLI_MODEL_REFERENCE.md) for complete details.
 
 > **🧠 Reasoning Effort Control**
@@ -111,8 +111,8 @@ See [CLI Model Reference](docs/CLI_MODEL_REFERENCE.md) for complete details.
 > Control reasoning depth per-participant for codex and droid adapters:
 > ```javascript
 > participants: [
->   {cli: "codex", model: "gpt-5.1-codex", reasoning_effort: "high"},    // Deep reasoning
->   {cli: "droid", model: "gpt-5.1-codex", reasoning_effort: "low"}      // Fast response
+>   {cli: "codex", model: "gpt-5.2-codex", reasoning_effort: "high"},    // Deep reasoning
+>   {cli: "droid", model: "gpt-5.2-codex", reasoning_effort: "low"}      // Fast response
 > ]
 > ```
 > - **Codex**: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
@@ -398,7 +398,7 @@ After configuration, restart Claude Code.
 ```javascript
 mcp__ai-counsel__deliberate({
   question: "Should we migrate to TypeScript?",
-  participants: [{cli: "claude", model: "sonnet"}, {cli: "codex", model: "gpt-5.1-codex"}],
+  participants: [{cli: "claude", model: "sonnet"}, {cli: "codex", model: "gpt-5.2-codex"}],
   mode: "quick"
 })
 ```
@@ -409,7 +409,7 @@ mcp__ai-counsel__deliberate({
   question: "JWT vs session-based auth?",
   participants: [
     {cli: "claude", model: "sonnet"},
-    {cli: "codex", model: "gpt-5.1-codex"}
+    {cli: "codex", model: "gpt-5.2-codex"}
   ],
   rounds: 3,
   mode: "conference"

--- a/adapters/codex.py
+++ b/adapters/codex.py
@@ -14,7 +14,7 @@ class CodexAdapter(BaseCLIAdapter):
 
     # Valid reasoning effort levels for Codex CLI
     # See: codex exec --help for current options
-    VALID_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
+    VALID_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high"}
 
     def __init__(
         self,
@@ -30,11 +30,16 @@ class CodexAdapter(BaseCLIAdapter):
             command: Command to execute (default: "codex")
             args: List of argument templates (from config.yaml with {reasoning_effort} placeholder)
             timeout: Timeout in seconds (default: 60)
-            default_reasoning_effort: Default reasoning effort level (none/minimal/low/medium/high/xhigh).
+            default_reasoning_effort: Default reasoning effort level (none/minimal/low/medium/high).
                 Used when {reasoning_effort} placeholder is in args. Can be overridden per-participant.
         """
         if args is None:
             raise ValueError("args must be provided from config.yaml")
+        if default_reasoning_effort is not None and default_reasoning_effort not in self.VALID_REASONING_EFFORTS:
+            raise ValueError(
+                f"Invalid default_reasoning_effort '{default_reasoning_effort}' for Codex. "
+                f"Valid values: {sorted(self.VALID_REASONING_EFFORTS)}"
+            )
         super().__init__(
             command=command,
             args=args,
@@ -60,7 +65,7 @@ class CodexAdapter(BaseCLIAdapter):
             context: Optional additional context
             is_deliberation: Whether this is part of a deliberation
             working_directory: Optional working directory for subprocess execution
-            reasoning_effort: Optional reasoning effort level (none, minimal, low, medium, high, xhigh).
+            reasoning_effort: Optional reasoning effort level (none, minimal, low, medium, high).
                 Substituted into {reasoning_effort} placeholder by base class.
 
         Returns:

--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,7 @@ cli_tools:
       ]
     timeout: 300
     default_reasoning_effort: "medium"
-    # Valid models: "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.1-codex-mini"
+  # Valid models: "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2"
     #
     # Reasoning Effort Levels:
     # - low: Fast responses with lighter reasoning
@@ -191,21 +191,21 @@ model_registry:
       tier: "premium"
       enabled: false
   codex:
-    - id: "gpt-5.1-codex-max"
-      label: "GPT-5.1 Codex Max"
+    - id: "gpt-5.2-codex"
+      label: "GPT-5.2 Codex"
       tier: "flagship"
       default: true
       enabled: true
-    - id: "gpt-5.1-codex"
-      label: "GPT-5.1 Codex"
-      tier: "coding"
+    - id: "gpt-5.1-codex-max"
+      label: "GPT-5.1 Codex Max"
+      tier: "flagship"
       enabled: true
     - id: "gpt-5.1-codex-mini"
       label: "GPT-5.1 Codex Mini"
       tier: "speed"
       enabled: true
-    - id: "gpt-5.1"
-      label: "GPT-5.1"
+    - id: "gpt-5.2"
+      label: "GPT-5.2"
       tier: "general"
       enabled: true
   droid:
@@ -218,12 +218,12 @@ model_registry:
       label: "Claude Sonnet 4.5 (via Droid)"
       tier: "balanced"
       enabled: true
-    - id: "gpt-5.1-codex"
-      label: "GPT-5.1 Codex (via Droid)"
+    - id: "gpt-5.2-codex"
+      label: "GPT-5.2 Codex (via Droid)"
       tier: "coding"
       enabled: true
-    - id: "gpt-5.1"
-      label: "GPT-5.1 (via Droid)"
+    - id: "gpt-5.2"
+      label: "GPT-5.2 (via Droid)"
       tier: "general"
       enabled: true
     - id: "glm-4.6"

--- a/models/schema.py
+++ b/models/schema.py
@@ -31,7 +31,7 @@ class Participant(BaseModel):
         default=None,
         description=(
             "Reasoning effort level for models that support it. "
-            "Codex supports: 'low', 'medium', 'high', 'extra-high'. "
+            "Codex supports: 'low', 'medium', 'high'. "
             "Droid supports: 'off', 'low', 'medium', 'high'. "
             "If omitted, uses the adapter's configured default."
         ),

--- a/server.py
+++ b/server.py
@@ -116,7 +116,7 @@ CLI_TITLES = {
 REASONING_EFFORT_SCHEMA: dict[str, dict] = {
     "codex": {
         "type": ["string", "null"],
-        "enum": ["none", "minimal", "low", "medium", "high", "xhigh", None],
+        "enum": ["none", "minimal", "low", "medium", "high", None],
         "description": "Reasoning effort level. Higher = more thorough but slower.",
         "default": None,
     },

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -478,7 +478,7 @@ class TestCodexReasoningEffort:
         assert "low" in adapter.VALID_REASONING_EFFORTS
         assert "medium" in adapter.VALID_REASONING_EFFORTS
         assert "high" in adapter.VALID_REASONING_EFFORTS
-        assert "xhigh" in adapter.VALID_REASONING_EFFORTS
+        assert "xhigh" not in adapter.VALID_REASONING_EFFORTS
 
     @pytest.mark.asyncio
     @patch("adapters.base.asyncio.create_subprocess_exec")
@@ -657,7 +657,7 @@ class TestDroidReasoningEffort:
             await adapter.invoke(
                 prompt="Test prompt",
                 model="factory-1",
-                reasoning_effort="xhigh"  # Invalid for Droid (valid for Codex)
+                reasoning_effort="xhigh"  # Invalid reasoning effort
             )
 
         assert "invalid reasoning_effort" in str(exc_info.value).lower()
@@ -1165,7 +1165,7 @@ class TestConfigBasedReasoningDefaults:
         assert "low" in adapter.VALID_REASONING_EFFORTS
         assert "medium" in adapter.VALID_REASONING_EFFORTS
         assert "high" in adapter.VALID_REASONING_EFFORTS
-        assert "xhigh" in adapter.VALID_REASONING_EFFORTS
+        assert "xhigh" not in adapter.VALID_REASONING_EFFORTS
 
         # Invalid values should not be in the set
         assert "off" not in adapter.VALID_REASONING_EFFORTS  # off is only valid for droid
@@ -1185,7 +1185,7 @@ class TestConfigBasedReasoningDefaults:
         assert "high" in adapter.VALID_REASONING_EFFORTS
 
         # Invalid values should not be in the set
-        assert "xhigh" not in adapter.VALID_REASONING_EFFORTS  # xhigh is only valid for codex
+        assert "xhigh" not in adapter.VALID_REASONING_EFFORTS
         assert "invalid" not in adapter.VALID_REASONING_EFFORTS
 
     @pytest.mark.asyncio
@@ -1201,7 +1201,7 @@ class TestConfigBasedReasoningDefaults:
             await adapter.invoke(
                 prompt="Test",
                 model="gpt-4",
-                reasoning_effort="invalid-level",
+                reasoning_effort="xhigh",
             )
 
         assert "invalid reasoning_effort" in str(exc_info.value).lower()
@@ -1220,7 +1220,7 @@ class TestConfigBasedReasoningDefaults:
             await adapter.invoke(
                 prompt="Test",
                 model="factory-1",
-                reasoning_effort="xhigh",  # Invalid for droid (valid for codex)
+                reasoning_effort="xhigh",  # Invalid for droid
             )
 
         assert "invalid reasoning_effort" in str(exc_info.value).lower()

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -404,7 +404,7 @@ class TestEngineReasoningEffort:
         request = DeliberateRequest(
             question="Test question with reasoning effort",
             participants=[
-                Participant(cli="codex", model="gpt-4", reasoning_effort="xhigh"),
+                Participant(cli="codex", model="gpt-4", reasoning_effort="high"),
                 Participant(cli="claude", model="sonnet"),
             ],
             rounds=2,
@@ -420,11 +420,11 @@ class TestEngineReasoningEffort:
         assert result.status == "complete"
         assert result.rounds_completed == 2
 
-        # Verify codex was called with reasoning_effort="xhigh" in each round
+        # Verify codex was called with reasoning_effort="high" in each round
         codex_calls = mock_adapters["codex"].invoke_mock.call_args_list
         for call in codex_calls:
             call_kwargs = call[1]
-            assert call_kwargs.get("reasoning_effort") == "xhigh"
+            assert call_kwargs.get("reasoning_effort") == "high"
 
     @pytest.mark.asyncio
     async def test_reasoning_effort_logged(self, mock_adapters, caplog):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -85,15 +85,12 @@ class TestParticipantReasoningEffort:
         p3 = Participant(cli="codex", model="gpt-4", reasoning_effort="high")
         assert p3.reasoning_effort == "high"
 
-        p4 = Participant(cli="codex", model="gpt-4", reasoning_effort="xhigh")
-        assert p4.reasoning_effort == "xhigh"
-
         # Test Droid values
-        p5 = Participant(cli="droid", model="factory-1", reasoning_effort="off")
-        assert p5.reasoning_effort == "off"
+        p4 = Participant(cli="droid", model="factory-1", reasoning_effort="off")
+        assert p4.reasoning_effort == "off"
 
-        p6 = Participant(cli="droid", model="factory-1", reasoning_effort="high")
-        assert p6.reasoning_effort == "high"
+        p5 = Participant(cli="droid", model="factory-1", reasoning_effort="high")
+        assert p5.reasoning_effort == "high"
 
     def test_reasoning_effort_serializes_correctly(self):
         """Test reasoning_effort serializes to dict correctly."""


### PR DESCRIPTION
- Add gpt-5.2-codex as new default codex model
- Add gpt-5.2 general model  
- Remove xhigh from valid reasoning efforts (no longer supported)
- Update docs and tests to reflect changes